### PR TITLE
update examples: Flipper, Counter and TokenLedger modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .artifacts
 .DS_Store
 .idea
+.logiclab

--- a/counter/README.md
+++ b/counter/README.md
@@ -2,11 +2,14 @@
 The `Counter` module is a simple logic with an internal 
 value state that can be retrieved or incremented.
 
+The [coco.nut](./coco.nut) file in this directory contains information about
+the module's compile preferences along with other application metadata
+
 ### Compiling the Module
 The `counter.coco` module can be compiled to the target the PISA Runtime on MOI
 by running the following command. Other compile targets are not currently supported.
 ```shell
-coco compile .
+coco compile
 ```
 
 The `counter.yaml` file is a manifest file that is the compiled artifact for 

--- a/counter/coco.nut
+++ b/counter/coco.nut
@@ -1,0 +1,20 @@
+[coco]
+version = "0.3.0"
+
+[module]
+name = "Counter"
+version = "0.0.1"
+license = ""
+repository = ""
+authors = ""
+
+[target]
+os = "MOI"
+arch = "PISA"
+
+[target.moi]
+format = "YAML"
+output = "counter"
+
+[target.pisa]
+format = "BIN"

--- a/counter/coco.nut
+++ b/counter/coco.nut
@@ -3,9 +3,9 @@ version = "0.3.0"
 
 [module]
 name = "Counter"
-version = "0.0.1"
-license = ""
-repository = ""
+version = "1.0.0"
+license = "MIT"
+repository = "https://github.com/sarvalabs/cocolang-examples/counter"
 authors = ""
 
 [target]

--- a/flipper/README.md
+++ b/flipper/README.md
@@ -2,11 +2,14 @@
 The `Flipper` module is a simple logic with an internal 
 boolean state that can be flipped, retrieved and modified.
 
+The [coco.nut](./coco.nut) file in this directory contains information about 
+the module's compile preferences along with other application metadata
+
 ### Compiling the Module
 The `flipper.coco` module can be compiled to the target the PISA Runtime on MOI
 by running the following command. Other compile targets are not currently supported.
 ```shell
-coco compile .
+coco compile
 ```
 
 The `flipper.yaml` file is a manifest file that is the compiled artifact for 

--- a/flipper/coco.nut
+++ b/flipper/coco.nut
@@ -1,0 +1,20 @@
+[coco]
+version = "0.3.0"
+
+[module]
+name = "Flipper"
+version = "0.0.1"
+license = ""
+repository = ""
+authors = ""
+
+[target]
+os = "MOI"
+arch = "PISA"
+
+[target.moi]
+format = "YAML"
+output = "flipper"
+
+[target.pisa]
+format = "BIN"

--- a/flipper/coco.nut
+++ b/flipper/coco.nut
@@ -3,9 +3,9 @@ version = "0.3.0"
 
 [module]
 name = "Flipper"
-version = "0.0.1"
-license = ""
-repository = ""
+version = "1.0.0"
+license = "MIT"
+repository = "https://github.com/sarvalabs/cocolang-examples/flipper"
 authors = ""
 
 [target]

--- a/flipper/flipper.yaml
+++ b/flipper/flipper.yaml
@@ -105,8 +105,7 @@ elements:
         hex: ""
         asm:
           - PLOAD $0 &0
-          - NOT $1 $0
-          - COPY $0 $1
+          - NOT $0 $0
           - PSAVE $0 &0
       catches: []
   - ptr: 6

--- a/tokenledger/README.md
+++ b/tokenledger/README.md
@@ -2,11 +2,14 @@
 The `TokenLedger` module is a simple logic with an internal 
 state that implements a tokenledger with necessary functionality.
 
+The [coco.nut](./coco.nut) file in this directory contains information about
+the module's compile preferences along with other application metadata
+
 ### Compiling the Module
 The `tokenledger.coco` module can be compiled to the target the PISA Runtime on MOI
 by running the following command. Other compile targets are not currently supported.
 ```shell
-coco compile .
+coco compile
 ```
 
 The `tokenledger.yaml` file is a manifest file that is the compiled artifact for 

--- a/tokenledger/coco.nut
+++ b/tokenledger/coco.nut
@@ -3,9 +3,9 @@ version = "0.3.0"
 
 [module]
 name = "TokenLedger"
-version = "0.0.1"
-license = ""
-repository = ""
+version = "1.0.0"
+license = "MIT"
+repository = "https://github.com/sarvalabs/cocolang-examples/tokenledger"
 authors = ""
 
 [target]

--- a/tokenledger/coco.nut
+++ b/tokenledger/coco.nut
@@ -1,0 +1,20 @@
+[coco]
+version = "0.3.0"
+
+[module]
+name = "TokenLedger"
+version = "0.0.1"
+license = ""
+repository = ""
+authors = ""
+
+[target]
+os = "MOI"
+arch = "PISA"
+
+[target.moi]
+format = "YAML"
+output = "tokenledger"
+
+[target.pisa]
+format = "BIN"

--- a/tokenledger/tokenledger.yaml
+++ b/tokenledger/tokenledger.yaml
@@ -189,23 +189,19 @@ elements:
           - ADDR $0 $0
           - NOT $1 $0
           - NOT $1 $1
-          - LDPTR1 $2 0xB
+          - LDPTR1 $2 0x9
           - JUMPI $2 $1
-          - PMAKE $1 0x3
-          - LDPTR1 $2 0x1
-          - CONST $2 $2
-          - JOIN $1 $1 $2
+          - LDPTR1 $1 0x1
+          - CONST $1 $1
           - THROW $1
           - DEST
           - OBTAIN $1 &0
           - NOT $2 $1
           - NOT $2 $2
-          - LDPTR1 $3 0x16
+          - LDPTR1 $3 0x12
           - JUMPI $3 $2
-          - PMAKE $2 0x3
-          - LDPTR1 $3 0x2
-          - CONST $3 $3
-          - JOIN $2 $2 $3
+          - LDPTR1 $2 0x2
+          - CONST $2 $2
           - THROW $2
           - DEST
           - PLOAD $2 &2
@@ -213,7 +209,7 @@ elements:
           - OBTAIN $4 &1
           - LT $5 $3 $4
           - NOT $5 $5
-          - LDPTR1 $6 0x21
+          - LDPTR1 $6 0x1D
           - JUMPI $6 $5
           - LDPTR1 $5 0x3
           - CONST $5 $5
@@ -246,12 +242,12 @@ elements:
           - ADDR $0 $0
           - PLOAD $1 &1
           - OBTAIN $2 &0
-          - ADD $3 $1 $2
-          - COPY $1 $3
+          - ADD $1 $1 $2
           - PSAVE $1 &1
           - PLOAD $1 &2
-          - GETIDX $3 $1 $0
-          - ADD $2 $3 $2
+          - GETIDX $2 $1 $0
+          - OBTAIN $3 &0
+          - ADD $2 $2 $3
           - SETIDX $1 $0 $2
           - PSAVE $1 &2
       catches: []
@@ -289,7 +285,8 @@ elements:
           - SETIDX $1 $0 $2
           - PSAVE $1 &2
           - PLOAD $0 &1
-          - SUB $1 $0 $3
+          - OBTAIN $1 &0
+          - SUB $1 $0 $1
           - COPY $0 $1
           - PSAVE $0 &1
       catches: []


### PR DESCRIPTION
- This PR updates the example modules to run for Cocolang `v0.3.0`
- `Flipper`, `Counter` and `TokenLedger` modules have been initialised with `coco.nut` files
- The compiled manifest for all example modules have been updated and reflect the optimized codegen of the `v0.3.0` compiler